### PR TITLE
add detail panel option

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": "airbnb",
+  "plugins": [
+    "react"
+  ],
+  "env": {
+    "browser": true
+  },
+  "rules": {
+    "import/no-extraneous-dependencies": "off",
+    "react/jsx-no-bind": "off"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ http://uxcore.github.io/uxcore/components/steps/
 |maxDescriptionWidth | 可选参数，指定步骤的详细描述文字的最大宽度。 | number | 无 | 100 |
 |showIcon | 步骤节点是否显示图标或数字 | bool | `true` or `false` | true |
 |type | 步骤条类型 | string | `default` `title-on-top` or `long-desc` | `default` |
-|showDetail | 可选参数[direction=vertical或type=long-desc不生效],是否显示详情[step的children] | bool | `true` `false` | `false` |
-|currentDetail | 可选参数[direction=vertical或type=long-desc不生效],指定当前正在显示的详情，从0开始记数 | number | `0` ... | `0` |
+|showDetail | 可选参数[direction=vertical或type=long-desc不生效],是否显示详情面板[step的children] | bool | `true` `false` | `false` |
+|currentDetail | 可选参数[direction=vertical或type=long-desc不生效],指定当前正在显示的详情面板，从0开始记数 | number | `0` ... | `0` |
 |onChange | 可选参数[direction=vertical或type=long-desc不生效],指定步骤icon点击事件回调,参数为被点击步骤对应数字 | func |  | (v)=>{} |
 
 ### Steps.Step

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ http://uxcore.github.io/uxcore/components/steps/
 |maxDescriptionWidth | 可选参数，指定步骤的详细描述文字的最大宽度。 | number | 无 | 100 |
 |showIcon | 步骤节点是否显示图标或数字 | bool | `true` or `false` | true |
 |type | 步骤条类型 | string | `default` `title-on-top` or `long-desc` | `default` |
+|showDetail | 可选参数[direction=vertical或type=long-desc不生效],是否显示详情[step的children] | bool | `true` `false` | `false` |
+|currentDetail | 可选参数[direction=vertical或type=long-desc不生效],指定当前正在显示的详情，从0开始记数 | number | `0` ... | `0` |
+|onChange | 可选参数[direction=vertical或type=long-desc不生效],指定步骤icon点击事件回调,参数为被点击步骤对应数字 | func |  | (v)=>{} |
 
 ### Steps.Step
 | 配置项 | 说明 | 类型 | 可选值 | 默认值 |

--- a/demo/StepsDemo.js
+++ b/demo/StepsDemo.js
@@ -31,15 +31,15 @@ class Demo extends React.Component {
         <h3>横向步骤条(标准)</h3>
         <div className="demo-box">
           <Steps current={3} showIcon onChange={this.cb.bind(this)} showDetail currentDetail={this.state.c}>
-            <Step key={0} title={'步骤一'} >步骤1, 利用回调函数改变currentDetail取值来切换详情</Step>
-            <Step key={1} title={'步骤二'} >步骤2, 利用回调函数改变currentDetail取值来切换详情</Step>
-            <Step key={2} title={'步骤三'} >步骤3, 利用回调函数改变currentDetail取值来切换详情</Step>
-            <Step key={3} title={'步骤四'} >步骤4, 利用回调函数改变currentDetail取值来切换详情</Step>
+            <Step key={0} title={'步骤一'} >步骤1, 利用回调函数改变currentDetail取值来切换详情面板</Step>
+            <Step key={1} title={'步骤二'} >步骤2, 利用回调函数改变currentDetail取值来切换详情面板</Step>
+            <Step key={2} title={'步骤三'} >步骤3, 利用回调函数改变currentDetail取值来切换详情面板</Step>
+            <Step key={3} title={'步骤四'} >步骤4, 利用回调函数改变currentDetail取值来切换详情面板</Step>
             <Step key={4} title={'已完成'} >步骤5
-              <br />我是比较高的最后一步
-              <br />我是比较高的最后一步
-              <br />我是比较高的最后一步
-              <br />我是比较高的最后一步
+              <br />利用回调函数改变currentDetail取值来切换详情面板
+              <br />利用回调函数改变currentDetail取值来切换详情面板
+              <br />利用回调函数改变currentDetail取值来切换详情面板
+              <br />利用回调函数改变currentDetail取值来切换详情面板
             </Step>
           </Steps>
         </div>

--- a/demo/StepsDemo.js
+++ b/demo/StepsDemo.js
@@ -13,85 +13,99 @@ import Steps, { Step } from '../src';
 
 class Demo extends React.Component {
 
-    constructor(props){
-        super(props);
-    }
+  constructor(props) {
+    super(props);
+    this.state = {
+      c: 4,
+    };
+  }
 
-    render() {
-        return (
-            <div>
-                <h2>步骤条</h2>
-                <h3>横向步骤条(标准)</h3>
-                <div className="demo-box">
-                    <Steps current="3" showIcon={true}>
-                        <Step key={0} title={'步骤一'} />
-                        <Step key={1} title={'步骤二'} />
-                        <Step key={2} title={'步骤三'} />
-                        <Step key={3} title={'步骤四'} />
-                        <Step key={4} title={'已完成'} />
-                    </Steps>
-                </div>
-                <div className="demo-box">
-                    <Steps current="5" showIcon={true}>
-                        <Step key={0} title={'步骤一'} />
-                        <Step key={1} title={'步骤二'} />
-                        <Step key={2} title={'步骤三'} />
-                        <Step key={3} title={'步骤四'} />
-                        <Step key={4} title={'已完成'} />
-                    </Steps>
-                </div>
-                <div className="demo-box">
-                    <Steps current="3" showIcon={false}>
-                        <Step key={0} title={'步骤一'} />
-                        <Step key={1} title={'步骤二'} />
-                        <Step key={2} title={'步骤三'} />
-                        <Step key={3} title={'步骤四'} />
-                        <Step key={4} title={'已完成'} />
-                    </Steps>
-                </div>
-                <h3>横向步骤条(样式二)</h3>
-                <div className="demo-box">
-                    <Steps current="3" showIcon={true}>
-                        <Step key={0} title={'步骤一'} description="内容文案内容文案内容文案内容文案" />
-                        <Step key={1} title={'步骤二'} description="内容文案内容文案内容文案内容文案" />
-                        <Step key={2} title={'步骤三'} description="内容文案内容文案内容文案内容文案" />
-                        <Step key={3} title={'步骤四'} description="内容文案内容文案内容文案内容文案" />
-                        <Step key={4} title={'已完成'} description="内容文案内容文案内容文案内容文案" />
-                    </Steps>
-                </div>
-                <h3>显示时间的步骤条</h3>
-                <div className="demo-box">
-                    <Steps current="3" showIcon={true} type="title-on-top">
-                        <Step key={0} title={'步骤一'} description="2016-1-12" />
-                        <Step key={1} title={'步骤二'} description="2016-1-13" />
-                        <Step key={2} title={'步骤三'} description="2016-1-14" />
-                        <Step key={3} title={'步骤四'} description="2016-1-15" />
-                        <Step key={4} title={'已完成'} description="2016-1-16" />
-                    </Steps>
-                </div>
-                <h3>大量文案描述的步骤条</h3>
-                <div className="demo-box">
-                    <Steps current="3" showIcon={true} type="long-desc">
-                        <Step key={0} title={'步骤一'} description="这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案" />
-                        <Step key={1} title={'步骤二'}  description="这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案" />
-                        <Step key={2} title={'步骤三'}  description="这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案" />
-                        <Step key={3} title={'步骤四'}  description="这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案" />
-                        <Step key={4} title={'已完成'}  description="这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案" />
-                    </Steps>
-                </div>
-                <h3>纵向步骤条</h3>
-                <div className="demo-box">
-                    <Steps current="3" showIcon={true} direction="vertical">
-                        <Step key={0} title={'步骤一'} description="这里是说明文案" />
-                        <Step key={1} title={'步骤二'} description="这里是说明文案" />
-                        <Step key={2} title={'步骤三'} description="这里是说明文案" />
-                        <Step key={3} title={'步骤四'} description="这里是说明文案" />
-                        <Step key={4} title={'已完成'} description="这里是说明文案" />
-                    </Steps>
-                </div>
-            </div>
-        );
-    }
+  cb(v) {
+    this.setState({ c: v });
+  }
+
+  render() {
+    return (
+      <div>
+        <h2>步骤条</h2>
+        <h3>横向步骤条(标准)</h3>
+        <div className="demo-box">
+          <Steps current={3} showIcon onChange={this.cb.bind(this)} showDetail currentDetail={this.state.c}>
+            <Step key={0} title={'步骤一'} >步骤1, 利用回调函数改变currentDetail取值来切换详情</Step>
+            <Step key={1} title={'步骤二'} >步骤2, 利用回调函数改变currentDetail取值来切换详情</Step>
+            <Step key={2} title={'步骤三'} >步骤3, 利用回调函数改变currentDetail取值来切换详情</Step>
+            <Step key={3} title={'步骤四'} >步骤4, 利用回调函数改变currentDetail取值来切换详情</Step>
+            <Step key={4} title={'已完成'} >步骤5
+              <br />我是比较高的最后一步
+              <br />我是比较高的最后一步
+              <br />我是比较高的最后一步
+              <br />我是比较高的最后一步
+            </Step>
+          </Steps>
+        </div>
+        <div className="demo-box">
+          <Steps current={5} showIcon >
+            <Step key={0} title={'步骤一'} />
+            <Step key={1} title={'步骤二'} />
+            <Step key={2} title={'步骤三'} />
+            <Step key={3} title={'步骤四'} />
+            <Step key={4} title={'已完成'} />
+          </Steps>
+        </div>
+        <div className="demo-box">
+          <Steps current={3} showIcon={false}>
+            <Step key={0} title={'步骤一'} />
+            <Step key={1} title={'步骤二'} />
+            <Step key={2} title={'步骤三'} />
+            <Step key={3} title={'步骤四'} />
+            <Step key={4} title={'已完成'} >
+                            我是最后一个元素
+            </Step>
+          </Steps>
+        </div>
+        <h3>横向步骤条(样式二)</h3>
+        <div className="demo-box">
+          <Steps current={3} showIcon>
+            <Step key={0} title={'步骤一'} description="内容文案内容文案内容文案内容文案" />
+            <Step key={1} title={'步骤二'} description="内容文案内容文案内容文案内容文案" />
+            <Step key={2} title={'步骤三'} description="内容文案内容文案内容文案内容文案" />
+            <Step key={3} title={'步骤四'} description="内容文案内容文案内容文案内容文案" />
+            <Step key={4} title={'已完成'} description="内容文案内容文案内容文案内容文案" />
+          </Steps>
+        </div>
+        <h3>显示时间的步骤条</h3>
+        <div className="demo-box">
+          <Steps current={3} showIcon type="title-on-top" >
+            <Step key={0} title={'步骤一'} description="2015-10-11" />
+            <Step key={1} title={'步骤二'} description="2015-10-12" />
+            <Step key={2} title={'步骤三'} description="2015-10-13" />
+            <Step key={3} title={'步骤四'} description="2015-10-14" />
+            <Step key={4} title={'已完成'} description="2015-10-15" />
+          </Steps>
+        </div>
+        <h3>大量文案描述的步骤条</h3>
+        <div className="demo-box">
+          <Steps current={3} showIcon type="long-desc" showDetail currentDetail={0}>
+            <Step key={0} title={'步骤一'} description="这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案" />
+            <Step key={1} title={'步骤二'} description="这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案" />
+            <Step key={2} title={'步骤三'} description="这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案" />
+            <Step key={3} title={'步骤四'} description="这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案" />
+            <Step key={4} title={'已完成'} description="这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案这里是说明文案" />
+          </Steps>
+        </div>
+        <h3>纵向步骤条</h3>
+        <div className="demo-box">
+          <Steps current={3} showIcon direction="vertical">
+            <Step key={0} title={'步骤一'} description="这里是说明文案" />
+            <Step key={1} title={'步骤二'} description="这里是说明文案" />
+            <Step key={2} title={'步骤三'} description="这里是说明文案" />
+            <Step key={3} title={'步骤四'} description="这里是说明文案" />
+            <Step key={4} title={'已完成'} description="这里是说明文案" />
+          </Steps>
+        </div>
+      </div>
+    );
+  }
 }
 
 module.exports = Demo;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "uxcore-steps",
- "version": "1.1.7",
+ "version": "1.1.8",
  "description": "uxcore-steps component for uxcore.",
  "repository": "https://github.com/uxcore/uxcore-steps.git",
  "author": "vincent.bian",
@@ -32,6 +32,11 @@
  "devDependencies": {
   "console-polyfill": "^0.2.2",
   "es5-shim": "^4.5.8",
+  "eslint": "^3.9.1",
+  "eslint-config-airbnb": "^12.0.0",
+  "eslint-plugin-import": "^1.16.0",
+  "eslint-plugin-jsx-a11y": "^2.2.3",
+  "eslint-plugin-react": "^6.4.1",
   "expect.js": "~0.3.1",
   "kuma-base": "1.x",
   "react": "0.14.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "uxcore-steps",
- "version": "1.1.8",
+ "version": "1.1.7",
  "description": "uxcore-steps component for uxcore.",
  "repository": "https://github.com/uxcore/uxcore-steps.git",
  "author": "vincent.bian",

--- a/src/Step.js
+++ b/src/Step.js
@@ -1,8 +1,12 @@
-import React from 'react'; 
+import React from 'react';
 
 class Step extends React.Component {
   constructor(props) {
-      super(props);
+    super(props);
+  }
+
+  onIconClick() {
+    this.props.hasDetail && this.props.onChange(Number(this.props.stepNumber) - 1);
   }
 
   render() {
@@ -13,48 +17,61 @@ class Step extends React.Component {
     const maxWidth = props.maxDescriptionWidth;
     const iconName = props.icon ? props.icon : 'check';
     let fixStyle = props.fixStyle;
-    let icon, stepCls = `${prefixCls}-item ${prefixCls}-status-${status}`, tail, description;
-    if (!props.icon && status !== 'process' || !props.stepLast) {
-        icon = <span className={`${prefixCls}-icon`}>{props.stepNumber}</span>;
+    let icon;
+    let stepCls = `${prefixCls}-item ${prefixCls}-status-${status}`;
+    let tail;
+    let description;
+    if ((!props.icon && status !== 'process') || !props.stepLast) {
+      icon = <span className={`${prefixCls}-icon`}>{props.stepNumber}</span>;
     } else {
-        icon = <span className={`${prefixCls}-icon ${iconPrefix}icon ${iconPrefix}icon-${iconName}`}></span>;
+      icon = <span className={`${prefixCls}-icon ${iconPrefix}icon ${iconPrefix}icon-${iconName}`} />;
     }
-    
+
     if (props.stepLast) {
-        stepCls += ` ${prefixCls}-item-last`;
+      stepCls += ` ${prefixCls}-item-last`;
     } else {
-        tail = <div className={`${prefixCls}-tail`}><i></i></div>
+      tail = <div className={`${prefixCls}-tail`}><i /></div>;
     }
     if (props.icon) {
-        stepCls += ` ${prefixCls}-custom`;
+      stepCls += ` ${prefixCls}-custom`;
     }
     if (props.description) {
-        description = (<div className={`${prefixCls}-description`}>
-          {props.description}
-        </div>)
+      description = (<div className={`${prefixCls}-description`}>
+        {props.description}
+      </div>);
     } else {
-        stepCls += ` ${prefixCls}-no-desc`;
+      stepCls += ` ${prefixCls}-no-desc`;
     }
 
     if (fixStyle) {
-        fixStyle.width = props.tailWidth;
+      fixStyle.width = props.tailWidth;
     } else {
-        fixStyle = {
-            width: props.tailWidth,
-        }
+      fixStyle = {
+        width: props.tailWidth,
+      };
     }
-    
+
+    const detailCls = `${prefixCls}-detail ${(props.showDetail ? `${prefixCls}-detail-current` : '')}`;
+    const headStyleFixed = { cursor: (props.hasDetail ? 'pointer' : 'default') };
     return (
-        <div className={`${stepCls}`} style={fixStyle}>
-            {tail}
-            <div className={`${prefixCls}-head`}>
-                <div className={`${prefixCls}-head-inner`}>{icon}</div>
-            </div>
-            <div className={`${prefixCls}-main`} style={{maxWidth: maxWidth}}>
-                <div className={`${prefixCls}-title`}>{props.title}</div>
-                {description}
-            </div>
+      <div className={`${stepCls}`} style={fixStyle}>
+        {tail}
+        <div className={`${prefixCls}-head`} style={headStyleFixed} onClick={this.onIconClick.bind(this)}>
+          <div className={`${prefixCls}-head-inner`}>{icon}</div>
         </div>
+        <div className={`${prefixCls}-main`} style={{ maxWidth }}>
+          <div className={`${prefixCls}-detail-arrow`} style={{ display: (props.showDetail ? 'block' : 'none') }} />
+          <div className={`${prefixCls}-title`}>{props.title}</div>
+          {description}
+        </div>
+        <div className={detailCls}>
+          <div className={`${prefixCls}-detail-con`} style={props.detailContentFixStyle}>
+            <div className={`${prefixCls}-detail-content`}>
+              {props.children}
+            </div>
+          </div>
+        </div>
+      </div>
     );
   }
 }

--- a/src/Steps.js
+++ b/src/Steps.js
@@ -41,7 +41,7 @@ class Steps extends React.Component {
          */
     $dom.children[len].style.position = 'absolute';
 
-    this._fixedLastDetailHeight();
+    this.fixLastDetailHeight();
 
         /*
          * 下面的代码是为了兼容window系统下滚动条出现后会占用宽度的问题。
@@ -91,7 +91,7 @@ class Steps extends React.Component {
       $dom.children[i].style.position = 'relative';
     }
     $dom.children[len].style.position = 'absolute';
-    this._fixedLastDetailHeight();
+    this.fixLastDetailHeight();
   }
 
   componentWillUnmount() {
@@ -106,7 +106,7 @@ class Steps extends React.Component {
   }
 
   _resize() {
-    this._fixedLastDetailHeight();
+    this.fixLastDetailHeight();
     const w = Math.floor(ReactDOM.findDOMNode(this).offsetWidth);
     if (this._previousStepsWidth === w) {
       return;
@@ -115,7 +115,7 @@ class Steps extends React.Component {
     this._update();
   }
 
-  _fixedLastDetailHeight() {
+  fixLastDetailHeight() {
         /*
          * 把整体高度调整为适合高度,处理最后一个detail是绝对定位的问题
          * */

--- a/src/Steps.js
+++ b/src/Steps.js
@@ -5,213 +5,244 @@
  * Copyright 2014-2015, Uxcore Team, Alinw.
  * All rights reserved.
  */
-
-import React from 'react'; 
+import React from 'react';
 
 class Steps extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      init: false,
+      tailWidth: 0,
+    };
+    this._previousStepsWidth = 0;
+    this._itemsWidth = [];
+  }
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            init: false,
-            tailWidth: 0
-        };
-        this._previousStepsWidth = 0;
-        this._itemsWidth = [];
+  componentDidMount() {
+    if (this.props.direction === 'vertical') {
+      return;
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.children.length !== this.props.children.length) {
-            if (this.props.direction === 'vertical') {
-                return;
-            }
-            const $dom = ReactDOM.findDOMNode(this);
-            const len = nextProps.children.length - 1;
-            this._itemsWidth = new Array(len + 1);
+    const $dom = ReactDOM.findDOMNode(this);
+    const len = $dom.children.length - 1;
+    this._itemsWidth = new Array(len + 1);
 
-            let i;
-            for (i = 0; i <= len - 1; i++) {
-                this._itemsWidth[i] = nextProps.maxDescriptionWidth;
-            }
-            this._itemsWidth[i] = nextProps.maxDescriptionWidth;
-            this._update(nextProps);
-        }
+    let i;
+    for (i = 0; i <= len - 1; i++) {
+      this._itemsWidth[i] = this.props.maxDescriptionWidth;
     }
-
-    componentDidMount() {
-        if (this.props.direction === 'vertical') {
-            return;
-        }
-        const $dom = ReactDOM.findDOMNode(this);
-        const len = $dom.children.length - 1;
-        this._itemsWidth = new Array(len + 1);
-
-        let i;
-        for (i = 0; i <= len - 1; i++) {
-            this._itemsWidth[i] = this.props.maxDescriptionWidth;
-        }
-        this._itemsWidth[i] = this.props.maxDescriptionWidth;
-        this._previousStepsWidth = Math.floor(ReactDOM.findDOMNode(this).offsetWidth);
-        this._update();
+    this._itemsWidth[i] = this.props.maxDescriptionWidth;
+    this._previousStepsWidth = Math.floor(ReactDOM.findDOMNode(this).offsetWidth);
+    this._update();
 
         /*
          * 把最后一个元素设置为absolute，是为了防止动态添加元素后滚动条出现导致的布局问题。
          * 未来不考虑ie8一类的浏览器后，会采用纯css来避免各种问题。
          */
-        $dom.children[len].style.position = 'absolute';
+    $dom.children[len].style.position = 'absolute';
+
+    this._fixedLastDetailHeight();
 
         /*
          * 下面的代码是为了兼容window系统下滚动条出现后会占用宽度的问题。
          * componentDidMount时滚动条还不一定出现了，这时候获取的宽度可能不是最终宽度。
          * 对于滚动条不占用宽度的浏览器，下面的代码也不二次render，_resize里面会判断要不要更新。
          */
-        setTimeout(() => {
-            this._resize();
-        });
+    setTimeout(() => {
+      this._resize();
+    });
 
-        this._resizeBind = this._resize.bind(this)
+    this._resizeBind = this._resize.bind(this);
 
-        if (window.attachEvent) {
-            window.attachEvent('onresize', this._resizeBind);
-        } else {
-            window.addEventListener('resize', this._resizeBind);
-        }
+    if (window.attachEvent) {
+      window.attachEvent('onresize', this._resizeBind);
+    } else {
+      window.addEventListener('resize', this._resizeBind);
     }
+  }
 
-    componentDidUpdate() {
-        this._resize();
-        const $dom = ReactDOM.findDOMNode(this);
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.children.length !== this.props.children.length) {
+      if (this.props.direction === 'vertical') {
+        return;
+      }
+      const len = nextProps.children.length - 1;
+      this._itemsWidth = new Array(len + 1);
 
-        const len = $dom.children.length - 1;
+      let i;
+      for (i = 0; i <= len - 1; i++) {
+        this._itemsWidth[i] = nextProps.maxDescriptionWidth;
+      }
+      this._itemsWidth[i] = nextProps.maxDescriptionWidth;
+      this._update(nextProps);
+    }
+  }
+
+  componentDidUpdate() {
+    this._resize();
+    const $dom = ReactDOM.findDOMNode(this);
+
+    const len = $dom.children.length - 1;
         /*
          * 把最后一个元素设置为absolute，是为了防止动态添加元素后滚动条出现导致的布局问题。
          * 未来不考虑ie8一类的浏览器后，会采用纯css来避免各种问题。
          */
-        for (let i = 0; i <= len; i++) {
-            $dom.children[i].style.position = 'relative';
-        }
-        $dom.children[len].style.position = 'absolute';
+    for (let i = 0; i <= len; i++) {
+      $dom.children[i].style.position = 'relative';
     }
+    $dom.children[len].style.position = 'absolute';
+    this._fixedLastDetailHeight();
+  }
 
-    componentWillUnmount() {
-        if (this.props.direction === 'vertical') {
-            return;
-        }
-        if (window.attachEvent) {
-            window.detachEvent('onresize', this._resizeBind);
-        } 
-        else {
-            window.removeEventListener('resize', this._resizeBind);
-        }
+  componentWillUnmount() {
+    if (this.props.direction === 'vertical') {
+      return;
     }
-
-    _resize() {
-        const w = Math.floor(ReactDOM.findDOMNode(this).offsetWidth);
-        if (this._previousStepsWidth === w) {
-            return;
-        }
-        this._previousStepsWidth = w;
-        this._update();
+    if (window.attachEvent) {
+      window.detachEvent('onresize', this._resizeBind);
+    } else {
+      window.removeEventListener('resize', this._resizeBind);
     }
+  }
 
-    _update(props = this.props) {
-        const len = props.children.length - 1;
-        let tw = this._itemsWidth.reduce((prev, w) => {
-            return prev + w;
-        }, 0);
-        const dw = Math.floor((this._previousStepsWidth - tw) / len) - 1;
-        if (dw <= 0) {
-            return;
-        }
-        this.setState({
-            init: true,
-            tailWidth: dw
-        });
+  _resize() {
+    this._fixedLastDetailHeight();
+    const w = Math.floor(ReactDOM.findDOMNode(this).offsetWidth);
+    if (this._previousStepsWidth === w) {
+      return;
     }
+    this._previousStepsWidth = w;
+    this._update();
+  }
 
-    render(){
-        let {
+  _fixedLastDetailHeight() {
+        /*
+         * 把整体高度调整为适合高度,处理最后一个detail是绝对定位的问题
+         * */
+    const $dom = ReactDOM.findDOMNode(this);
+    const len = $dom.children.length - 1;
+    const $domLastDetail = $dom.children[len];
+    if (this.props.currentDetail === len && $dom.offsetHeight <= $domLastDetail.offsetHeight) {
+      $dom.style.height = `${$domLastDetail.offsetHeight}px`;
+    } else {
+      $dom.style.height = 'auto';
+    }
+  }
+
+  _update(props = this.props) {
+    const len = props.children.length - 1;
+    const tw = this._itemsWidth.reduce((prev, w) =>
+            prev + w
+            , 0);
+    const dw = Math.floor((this._previousStepsWidth - tw) / len) - 1;
+    if (dw <= 0) {
+      return;
+    }
+    this.setState({
+      init: true,
+      tailWidth: dw,
+    });
+  }
+
+  render() {
+    let { current } = this.props;
+    const {
             prefixCls,
             className,
             children,
             maxDescriptionWidth,
             iconPrefix,
-            size,
             direction,
             showIcon,
-            current,
-            type
+            type,
+            showDetail,
+            currentDetail,
+            onChange,
         } = this.props;
-        let len = children.length - 1;
-        let iws = this._itemsWidth;
-        let clsName = prefixCls;
-        let fixStyle;
-        if (direction === 'vertical') {
-            clsName += ` ${prefixCls}-vertical ${className}`;
-        } else {
-            clsName += ` ${prefixCls}-type-${type} ${className}`;
+    const len = children.length - 1;
+    const iws = this._itemsWidth;
+    let clsName = prefixCls;
+    let fixStyle;
+    if (direction === 'vertical') {
+      clsName += ` ${prefixCls}-vertical ${className}`;
+    } else {
+      clsName += ` ${prefixCls}-type-${type} ${className}`;
             // fix #5
-            if (type === 'default') {
-                let descItemsCount = children.filter(d => d.props.description).length;
-                if (descItemsCount > 0 && descItemsCount !== len + 1) {
-                    fixStyle = {
-                        marginTop: 70,
-                    };
-                }
-            }
+      if (type === 'default') {
+        const descItemsCount = children.filter(d => d.props.description).length;
+        if (descItemsCount > 0 && descItemsCount !== len + 1) {
+          fixStyle = {
+            marginTop: 70,
+          };
         }
-        if (!showIcon) {
-            clsName += ` ${prefixCls}-noicon`;
-        }
-        if (typeof current !== 'number') {
-            current = Number(current);
-        }
-
-        return (
-            <div className={clsName}>
-                {React.Children.map(children, (ele, idx) => {
-                    let np = {
-                        stepNumber: showIcon ? (idx + 1).toString(): '',
-                        stepLast: idx === len,
-                        tailWidth: iws.length === 0 || idx === len ? 'auto' : iws[idx] + this.state.tailWidth,
-                        prefixCls: prefixCls,
-                        iconPrefix: iconPrefix,
-                        maxDescriptionWidth: maxDescriptionWidth,
-                        fixStyle: fixStyle,
-                    };
-                    if (!ele.props.status) {
-                        np.status = idx == current ? 'process' : (idx < current ? 'finish' : 'wait');
-                    }
-                    return React.cloneElement(ele, np);
-                }, this)}
-            </div>
-        );
+      }
     }
+    if (!showIcon) {
+      clsName += ` ${prefixCls}-noicon`;
+    }
+    if (typeof current !== 'number') {
+      current = Number(current);
+    }
+
+    return (
+      <div className={clsName}>
+        {React.Children.map(children, (ele, idx) => {
+          const np = {
+            stepNumber: showIcon ? (idx + 1).toString() : '',
+            stepLast: idx === len,
+            tailWidth: iws.length === 0 || idx === len ? 'auto' : iws[idx] + this.state.tailWidth,
+            prefixCls,
+            iconPrefix,
+            maxDescriptionWidth,
+            fixStyle,
+            showDetail: showDetail && currentDetail === idx && direction !== 'vertical' && type !== 'long-desc',
+            detailContentFixStyle: {
+              marginLeft: !isNaN(-(iws[idx] + this.state.tailWidth) * idx) ? -(iws[idx] + this.state.tailWidth) * idx : 0,
+              width: this._previousStepsWidth,
+            },
+            onChange,
+            hasDetail: showDetail && direction !== 'vertical' && type !== 'long-desc',
+          };
+          if (!ele.props.status) {
+            np.status = idx === current ? 'process' : idx < current ? 'finish' : 'wait';
+          }
+          return React.cloneElement(ele, np);
+        }, this)}
+      </div>
+    );
+  }
 }
 
 Steps.defaultProps = {
-    prefixCls: 'kuma-step',
-    className: '',
-    iconPrefix: '',
-    maxDescriptionWidth: 100,
-    current: 0,
-    direction: '',
-    showIcon: true,
-    type: 'default'    
+  prefixCls: 'kuma-step',
+  className: '',
+  iconPrefix: '',
+  maxDescriptionWidth: 100,
+  current: 0,
+  direction: '',
+  showIcon: true,
+  type: 'default',
+  showDetail: false,
+  currentDetail: 0,
+  onChange: () => {
+  },
 };
 
 // http://facebook.github.io/react/docs/reusable-components.html
 Steps.propTypes = {
-    prefixCls: React.PropTypes.string,
-    className: React.PropTypes.string,
-    iconPrefix: React.PropTypes.string,
-    maxDescriptionWidth: React.PropTypes.number,
-    current: React.PropTypes.number,
-    direction: React.PropTypes.string,
-    showIcon: React.PropTypes.bool,
-    type: React.PropTypes.oneOf(['default', 'title-on-top', 'long-desc'])
+  prefixCls: React.PropTypes.string,
+  className: React.PropTypes.string,
+  iconPrefix: React.PropTypes.string,
+  maxDescriptionWidth: React.PropTypes.number,
+  current: React.PropTypes.number,
+  direction: React.PropTypes.string,
+  showIcon: React.PropTypes.bool,
+  type: React.PropTypes.oneOf(['default', 'title-on-top', 'long-desc']),
+  showDetail: React.PropTypes.bool,
+  currentDetail: React.PropTypes.number,
+  onChange: React.PropTypes.func,
 };
 
-Steps.displayName = "Steps";
+Steps.displayName = 'Steps';
 
 export default Steps;

--- a/src/Steps.less
+++ b/src/Steps.less
@@ -18,6 +18,27 @@
         min-height: 70px;
         margin-top: 74px;
         vertical-align: top;
+        .@{__step-prefix-cls}-main {
+            .@{__step-prefix-cls}-detail-arrow {
+                position: absolute;
+                top: 45px;
+                font-family: kuma;
+                font-size: 34px;
+                margin-left: -50%;
+                left: 13px;
+                &::before{
+                    content:"\e613";
+                    color:#ccc;
+                }
+                &::after{
+                    content:"\e613";
+                    color: #f2f2f2;
+                    position: absolute;
+                    top: 2px;
+                    left: 0;
+                }
+            }
+        }
     }
     .@{__step-prefix-cls}-item-last {
         .@{__step-prefix-cls}-title {
@@ -41,6 +62,7 @@
         position: absolute;
         left: 0;
         top: 8px;
+        z-index:1;
         .@{__step-prefix-cls}-icon {
             display: inline-block;
             width: @__step-normal-icon-size;
@@ -276,7 +298,7 @@
                 background-color: @gray-lighter;
             }
         }
-        
+
         &.@{__step-prefix-cls}-vertical {
             .@{__step-prefix-cls}-head {
                 top: 5px;
@@ -285,6 +307,22 @@
             .@{__step-prefix-cls}-tail {
                 padding: 27px 0 0 1px;
             }
+        }
+    }
+    //包含详情的
+    .@{__step-prefix-cls}-detail {
+        > .@{__step-prefix-cls}-detail-con{
+            display:none;
+            margin-top: 74px;
+            width: 800px;
+            background-color: rgba(242, 242, 242, 1);
+            padding: 10px;
+            border: 1px solid #ccc;
+        }
+    }
+    .@{__step-prefix-cls}-detail.@{__step-prefix-cls}-detail-current {
+        > .@{__step-prefix-cls}-detail-con{
+            display:block;
         }
     }
 }


### PR DESCRIPTION
添加了步骤条展示详情panel支持，新增三个参数，均为可选参数
  showDetail 显示详情panel [详情panel就是step的chldren]
  currentDetail 当前显示详情panel的数值，从0计数
  onChange 步骤icon点击事件回调，参数为对应步骤的数值
以上新参数都是可选，且在以下情况下是不生效的[因为样式问题]：
  direction == 'vertical'
  type == 'long-desc'
内容调整较多，主要是Eslint的代码格式化对源代码的修改，源代码功能并无修改，即向后兼容